### PR TITLE
Enable icons UI kit vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "build": "next build",
     "dev": "next dev",
     "start": "next start",
-    "test": "vitest",
+    "test": "vitest --run",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",

--- a/src/ui-kit/icons/IconAdd.test.tsx
+++ b/src/ui-kit/icons/IconAdd.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconAdd } from './IconAdd';
+
+describe('IconAdd Component', () => {
+  it('renders with default props', () => {
+    render(<IconAdd data-testid="icon" />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toBeInTheDocument();
+    expect(icon.tagName.toLowerCase()).toBe('svg');
+    expect(icon).toHaveAttribute('width', '24');
+    expect(icon).toHaveAttribute('height', '24');
+    expect(icon.querySelector('path')).toHaveAttribute('fill', 'currentColor');
+  });
+
+  it('renders with custom size', () => {
+    const customSize = 32;
+    render(<IconAdd data-testid="icon" size={customSize} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('width', customSize.toString());
+    expect(icon).toHaveAttribute('height', customSize.toString());
+  });
+
+  it('renders with custom color', () => {
+    const customColor = '#FF0000';
+    render(<IconAdd data-testid="icon" color={customColor} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon.querySelector('path')).toHaveAttribute('fill', customColor);
+  });
+
+  it('spreads additional SVG props', () => {
+    render(<IconAdd data-testid="icon" className="custom-class" aria-label="Add icon" />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('class', 'custom-class');
+    expect(icon).toHaveAttribute('aria-label', 'Add icon');
+  });
+});

--- a/src/ui-kit/icons/IconArrowDown.test.tsx
+++ b/src/ui-kit/icons/IconArrowDown.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconArrowDown } from './IconArrowDown';
+
+describe('IconArrowDown Component', () => {
+  it('renders with default props', () => {
+    render(<IconArrowDown data-testid="icon" />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toBeInTheDocument();
+    expect(icon.tagName.toLowerCase()).toBe('svg');
+    expect(icon).toHaveAttribute('width', '16');
+    expect(icon).toHaveAttribute('height', '16');
+    expect(icon).toHaveClass('rotate-180');
+    expect(icon.querySelector('path')).toHaveAttribute('fill', 'currentColor');
+  });
+
+  it('renders with custom size', () => {
+    const customSize = 32;
+    render(<IconArrowDown data-testid="icon" size={customSize} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('width', customSize.toString());
+    expect(icon).toHaveAttribute('height', customSize.toString());
+  });
+
+  it('renders with custom color', () => {
+    const customColor = '#FF0000';
+    render(<IconArrowDown data-testid="icon" color={customColor} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon.querySelector('path')).toHaveAttribute('fill', customColor);
+  });
+
+  it('spreads additional SVG props while maintaining default class', () => {
+    render(
+      <IconArrowDown data-testid="icon" className="custom-class" aria-label="Arrow down icon" />
+    );
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveClass('rotate-180', 'custom-class');
+    expect(icon).toHaveAttribute('aria-label', 'Arrow down icon');
+  });
+});

--- a/src/ui-kit/icons/IconArrowDown.tsx
+++ b/src/ui-kit/icons/IconArrowDown.tsx
@@ -12,8 +12,8 @@ export const IconArrowDown: React.FC<IconProps> = ({
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    className="rotate-180"
     {...nativeProps}
+    className={`rotate-180 ${nativeProps.className || ''}`}
   >
     <path
       fillRule="evenodd"

--- a/src/ui-kit/icons/IconArrowDownUp.test.tsx
+++ b/src/ui-kit/icons/IconArrowDownUp.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconArrowDownUp } from './IconArrowDownUp';
+
+describe('IconArrowDownUp Component', () => {
+  it('renders with default props', () => {
+    render(<IconArrowDownUp data-testid="icon" />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toBeInTheDocument();
+    expect(icon.tagName.toLowerCase()).toBe('svg');
+    expect(icon).toHaveAttribute('width', '16');
+    expect(icon).toHaveAttribute('height', '16');
+    expect(icon).toHaveAttribute('viewBox', '0 0 16 16');
+    const path = icon.querySelector('path');
+    expect(path).toHaveAttribute('stroke', 'currentColor');
+    expect(path).toHaveAttribute('stroke-width', '1.5');
+    expect(path).toHaveAttribute('stroke-linecap', 'round');
+    expect(path).toHaveAttribute('stroke-linejoin', 'round');
+  });
+
+  it('renders with custom size', () => {
+    const customSize = 32;
+    render(<IconArrowDownUp data-testid="icon" size={customSize} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('width', customSize.toString());
+    expect(icon).toHaveAttribute('height', customSize.toString());
+  });
+
+  it('renders with custom color', () => {
+    const customColor = '#FF0000';
+    render(<IconArrowDownUp data-testid="icon" color={customColor} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon.querySelector('path')).toHaveAttribute('stroke', customColor);
+  });
+
+  it('spreads additional SVG props', () => {
+    render(
+      <IconArrowDownUp data-testid="icon" className="custom-class" aria-label="Arrow up and down" />
+    );
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveClass('custom-class');
+    expect(icon).toHaveAttribute('aria-label', 'Arrow up and down');
+  });
+});

--- a/src/ui-kit/icons/IconArrowLeft.test.tsx
+++ b/src/ui-kit/icons/IconArrowLeft.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconArrowLeft } from './IconArrowLeft';
+
+describe('IconArrowLeft Component', () => {
+  it('renders with default props', () => {
+    render(<IconArrowLeft data-testid="icon" />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toBeInTheDocument();
+    expect(icon.tagName.toLowerCase()).toBe('svg');
+    expect(icon).toHaveAttribute('width', '16');
+    expect(icon).toHaveAttribute('height', '16');
+    expect(icon).toHaveAttribute('viewBox', '0 0 16 12');
+    expect(icon).toHaveClass('stroke-current');
+    const path = icon.querySelector('path');
+    expect(path).toHaveAttribute('stroke', 'currentColor');
+    expect(path).toHaveAttribute('stroke-width', '2');
+    expect(path).toHaveAttribute('stroke-linecap', 'round');
+    expect(path).toHaveAttribute('stroke-linejoin', 'round');
+  });
+
+  it('renders with custom size', () => {
+    const customSize = 32;
+    render(<IconArrowLeft data-testid="icon" size={customSize} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('width', customSize.toString());
+    expect(icon).toHaveAttribute('height', customSize.toString());
+  });
+
+  it('renders with custom color', () => {
+    const customColor = '#FF0000';
+    render(<IconArrowLeft data-testid="icon" color={customColor} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon.querySelector('path')).toHaveAttribute('stroke', customColor);
+  });
+
+  it('merges className with default class', () => {
+    render(<IconArrowLeft data-testid="icon" className="custom-class" />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveClass('stroke-current', 'custom-class');
+  });
+
+  it('spreads additional SVG props', () => {
+    render(<IconArrowLeft data-testid="icon" aria-label="Left arrow" />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('aria-label', 'Left arrow');
+  });
+});

--- a/src/ui-kit/icons/IconButton.test.tsx
+++ b/src/ui-kit/icons/IconButton.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IconButton } from './IconButton';
+
+describe('IconButton Component', () => {
+  it('renders with default props', () => {
+    render(<IconButton data-testid="icon-button" />);
+    const svg = screen.getByTestId('icon-button');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(svg).toHaveAttribute('fill', 'none');
+  });
+
+  it('renders with custom size and color', () => {
+    render(<IconButton size={32} color="#FF0000" data-testid="icon-button" />);
+    const svg = screen.getByTestId('icon-button');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+
+    const strokes = svg.querySelectorAll('[stroke="#FF0000"]');
+    const fills = svg.querySelectorAll('[fill="#FF0000"]');
+    expect(strokes.length).toBeGreaterThan(0);
+    expect(fills.length).toBeGreaterThan(0);
+  });
+
+  it('passes additional SVG props', () => {
+    render(
+      <IconButton data-testid="icon-button" className="custom-icon" aria-label="Button Icon" />
+    );
+    const svg = screen.getByTestId('icon-button');
+
+    expect(svg).toHaveAttribute('data-testid', 'icon-button');
+    expect(svg).toHaveClass('custom-icon');
+    expect(svg).toHaveAttribute('aria-label', 'Button Icon');
+  });
+
+  it('has correct SVG structure', () => {
+    render(<IconButton data-testid="icon-button" />);
+    const svg = screen.getByTestId('icon-button');
+
+    const rects = svg.querySelectorAll('rect');
+    expect(rects.length).toBe(3);
+
+    // Check the main background rect
+    const backgroundRect = rects[0];
+    expect(backgroundRect).toHaveAttribute('x', '2');
+    expect(backgroundRect).toHaveAttribute('y', '8');
+    expect(backgroundRect).toHaveAttribute('width', '20');
+    expect(backgroundRect).toHaveAttribute('height', '8');
+    expect(backgroundRect).toHaveAttribute('rx', '4');
+  });
+});

--- a/src/ui-kit/icons/IconCopy.test.tsx
+++ b/src/ui-kit/icons/IconCopy.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IconCopy } from './IconCopy';
+
+describe('IconCopy Component', () => {
+  it('renders with default props', () => {
+    render(<IconCopy data-testid="icon-copy" />);
+    const svg = screen.getByTestId('icon-copy');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 20 21');
+    expect(svg).toHaveAttribute('fill', 'none');
+  });
+
+  it('renders with custom size and color', () => {
+    render(<IconCopy size={32} color="#FF0000" data-testid="icon-copy" />);
+    const svg = screen.getByTestId('icon-copy');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+
+    const strokes = svg.querySelectorAll('[stroke="#FF0000"]');
+    expect(strokes.length).toBeGreaterThan(0);
+  });
+
+  it('passes additional SVG props', () => {
+    render(<IconCopy data-testid="icon-copy" className="custom-icon" aria-label="Copy Icon" />);
+    const svg = screen.getByTestId('icon-copy');
+
+    expect(svg).toHaveAttribute('data-testid', 'icon-copy');
+    expect(svg).toHaveClass('custom-icon');
+    expect(svg).toHaveAttribute('aria-label', 'Copy Icon');
+  });
+
+  it('has correct SVG structure', () => {
+    render(<IconCopy data-testid="icon-copy" />);
+    const svg = screen.getByTestId('icon-copy');
+
+    const paths = svg.querySelectorAll('path');
+    expect(paths.length).toBe(1);
+
+    const path = paths[0];
+    expect(path.getAttribute('stroke')).toBe('currentColor');
+    expect(path.getAttribute('stroke-width')).toBe('2');
+    expect(path.getAttribute('stroke-linecap')).toBe('round');
+    expect(path.getAttribute('stroke-linejoin')).toBe('round');
+  });
+});

--- a/src/ui-kit/icons/IconCreate.test.tsx
+++ b/src/ui-kit/icons/IconCreate.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IconCreate } from './IconCreate';
+
+describe('IconCreate Component', () => {
+  it('renders with default props', () => {
+    render(<IconCreate data-testid="icon-create" />);
+    const svg = screen.getByTestId('icon-create');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(svg).toHaveAttribute('fill', 'none');
+  });
+
+  it('renders with custom size and color', () => {
+    render(<IconCreate size={32} color="#FF0000" data-testid="icon-create" />);
+    const svg = screen.getByTestId('icon-create');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+
+    const strokes = svg.querySelectorAll('[stroke="#FF0000"]');
+    expect(strokes.length).toBeGreaterThan(0);
+  });
+
+  it('passes additional SVG props', () => {
+    render(
+      <IconCreate data-testid="icon-create" className="custom-icon" aria-label="Create Icon" />
+    );
+    const svg = screen.getByTestId('icon-create');
+
+    expect(svg).toHaveAttribute('data-testid', 'icon-create');
+    expect(svg).toHaveClass('custom-icon');
+    expect(svg).toHaveAttribute('aria-label', 'Create Icon');
+  });
+
+  it('has correct SVG structure', () => {
+    render(<IconCreate data-testid="icon-create" />);
+    const svg = screen.getByTestId('icon-create');
+
+    const paths = svg.querySelectorAll('path');
+    expect(paths.length).toBe(1);
+
+    const path = paths[0];
+    expect(path.getAttribute('stroke')).toBe('currentColor');
+    expect(path.getAttribute('stroke-width')).toBe('2');
+    expect(path.getAttribute('stroke-linecap')).toBe('round');
+    expect(path.getAttribute('stroke-linejoin')).toBe('round');
+  });
+});

--- a/src/ui-kit/icons/IconDelete.test.tsx
+++ b/src/ui-kit/icons/IconDelete.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { IconDelete } from './IconDelete';
+
+describe('IconDelete Component', () => {
+  it('renders with default props', () => {
+    const { getByTestId } = render(<IconDelete data-testid="delete-icon" />);
+    const svg = getByTestId('delete-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+  });
+
+  it('renders with custom size', () => {
+    const { getByTestId } = render(<IconDelete size={32} data-testid="delete-icon" />);
+    const svg = getByTestId('delete-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color', () => {
+    const { container } = render(<IconDelete color="red" data-testid="delete-icon" />);
+    const path = container.querySelector('path');
+
+    expect(path).toHaveAttribute('stroke', 'red');
+  });
+
+  it('passes through additional native props', () => {
+    const { getByTestId } = render(
+      <IconDelete data-testid="delete-icon" className="custom-class" aria-label="Delete" />
+    );
+    const svg = getByTestId('delete-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Delete');
+  });
+});

--- a/src/ui-kit/icons/IconDownload.test.tsx
+++ b/src/ui-kit/icons/IconDownload.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconDownload } from './IconDownload';
+
+describe('IconDownload Component', () => {
+  it('renders with default props', () => {
+    render(<IconDownload data-testid="download-icon" />);
+    const svg = screen.getByTestId('download-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconDownload size={32} data-testid="download-icon" />);
+    const svg = screen.getByTestId('download-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color', () => {
+    render(<IconDownload color="red" data-testid="download-icon" />);
+    const path = screen.getByTestId('download-icon').querySelector('path');
+
+    expect(path).toHaveAttribute('stroke', 'red');
+  });
+
+  it('passes through additional native props', () => {
+    render(
+      <IconDownload data-testid="download-icon" className="custom-class" aria-label="Download" />
+    );
+    const svg = screen.getByTestId('download-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Download');
+  });
+});

--- a/src/ui-kit/icons/IconEdit.test.tsx
+++ b/src/ui-kit/icons/IconEdit.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconEdit } from './IconEdit';
+
+describe('IconEdit Component', () => {
+  it('renders with default props', () => {
+    render(<IconEdit data-testid="edit-icon" />);
+    const svg = screen.getByTestId('edit-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 20 20');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconEdit size={32} data-testid="edit-icon" />);
+    const svg = screen.getByTestId('edit-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color', () => {
+    render(<IconEdit color="red" data-testid="edit-icon" />);
+    const path = screen.getByTestId('edit-icon').querySelector('path');
+
+    expect(path).toHaveAttribute('stroke', 'red');
+  });
+
+  it('passes through additional native props', () => {
+    render(<IconEdit data-testid="edit-icon" className="custom-class" aria-label="Edit" />);
+    const svg = screen.getByTestId('edit-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Edit');
+  });
+});

--- a/src/ui-kit/icons/IconError.test.tsx
+++ b/src/ui-kit/icons/IconError.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconError } from './IconError';
+
+describe('IconError Component', () => {
+  it('renders with default props', () => {
+    render(<IconError data-testid="error-icon" />);
+    const svg = screen.getByTestId('error-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '80');
+    expect(svg).toHaveAttribute('height', '80');
+    expect(svg).toHaveAttribute('viewBox', '0 0 80 80');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconError size={100} data-testid="error-icon" />);
+    const svg = screen.getByTestId('error-icon');
+
+    expect(svg).toHaveAttribute('width', '100');
+    expect(svg).toHaveAttribute('height', '100');
+  });
+
+  it('renders with correct colors and shapes', () => {
+    render(<IconError data-testid="error-icon" />);
+    const svg = screen.getByTestId('error-icon');
+    const [outerRect, innerRect] = svg.querySelectorAll('rect');
+    const path = svg.querySelector('path');
+
+    expect(outerRect).toHaveAttribute('fill', '#FFF2E8');
+    expect(innerRect).toHaveAttribute('fill', '#FF4A32');
+    expect(path).toHaveAttribute('stroke', 'white');
+  });
+
+  it('passes through additional native props', () => {
+    render(<IconError data-testid="error-icon" className="custom-class" aria-label="Error" />);
+    const svg = screen.getByTestId('error-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Error');
+  });
+});

--- a/src/ui-kit/icons/IconHelp.test.tsx
+++ b/src/ui-kit/icons/IconHelp.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconHelp } from './IconHelp';
+
+describe('IconHelp Component', () => {
+  it('renders with default props', () => {
+    render(<IconHelp data-testid="help-icon" />);
+    const svg = screen.getByTestId('help-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconHelp size={32} data-testid="help-icon" />);
+    const svg = screen.getByTestId('help-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color', () => {
+    render(<IconHelp color="red" data-testid="help-icon" />);
+    const paths = screen.getByTestId('help-icon').querySelectorAll('path');
+    paths.forEach(path => {
+      const hasStroke = path.hasAttribute('stroke');
+      const hasFill = path.hasAttribute('fill');
+      if (hasStroke) expect(path).toHaveAttribute('stroke', 'red');
+      if (hasFill) expect(path).toHaveAttribute('fill', 'red');
+    });
+  });
+
+  it('passes through additional native props', () => {
+    render(<IconHelp data-testid="help-icon" className="custom-class" aria-label="Help" />);
+    const svg = screen.getByTestId('help-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Help');
+  });
+});

--- a/src/ui-kit/icons/IconLike.test.tsx
+++ b/src/ui-kit/icons/IconLike.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { IconLike } from './IconLike';
+
+describe('IconLike Component', () => {
+  it('renders with default props', () => {
+    const { getByTestId } = render(<IconLike data-testid="like-icon" />);
+    const icon = getByTestId('like-icon');
+
+    // Check SVG attributes
+    expect(icon).toHaveAttribute('width', '24');
+    expect(icon).toHaveAttribute('height', '24');
+    expect(icon).toHaveAttribute('viewBox', '0 0 24 24');
+
+    // Check stroke color is currentColor by default
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('stroke', 'currentColor');
+    });
+  });
+
+  it('renders with custom size and color', () => {
+    const { getByTestId } = render(<IconLike data-testid="like-icon" size={32} color="#FF0000" />);
+    const icon = getByTestId('like-icon');
+
+    // Check custom size
+    expect(icon).toHaveAttribute('width', '32');
+    expect(icon).toHaveAttribute('height', '32');
+
+    // Check custom color
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('stroke', '#FF0000');
+    });
+  });
+
+  it('passes through additional SVG props', () => {
+    const { getByTestId } = render(
+      <IconLike data-testid="like-icon" className="custom-class" aria-label="Like Icon" />
+    );
+    const icon = getByTestId('like-icon');
+
+    expect(icon).toHaveClass('custom-class');
+    expect(icon).toHaveAttribute('aria-label', 'Like Icon');
+  });
+
+  it('has correct number of paths', () => {
+    const { getByTestId } = render(<IconLike data-testid="like-icon" />);
+    const icon = getByTestId('like-icon');
+    const paths = icon.querySelectorAll('path');
+
+    expect(paths.length).toBe(2);
+  });
+});

--- a/src/ui-kit/icons/IconLogo.test.tsx
+++ b/src/ui-kit/icons/IconLogo.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { IconLogo } from './IconLogo';
+
+describe('IconLogo Component', () => {
+  it('renders with default props', () => {
+    const { getByTestId } = render(<IconLogo data-testid="logo-icon" />);
+    const icon = getByTestId('logo-icon');
+
+    // Check SVG attributes
+    expect(icon).toHaveAttribute('width', '24');
+    expect(icon).toHaveAttribute('height', '24');
+    expect(icon).toHaveAttribute('viewBox', '0 0 24 24');
+
+    // Check fill color is currentColor by default
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill', 'currentColor');
+    });
+  });
+
+  it('renders with custom size and color', () => {
+    const { getByTestId } = render(<IconLogo data-testid="logo-icon" size={32} color="#FF0000" />);
+    const icon = getByTestId('logo-icon');
+
+    // Check custom size
+    expect(icon).toHaveAttribute('width', '32');
+    expect(icon).toHaveAttribute('height', '32');
+
+    // Check custom color
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill', '#FF0000');
+    });
+  });
+
+  it('passes through additional SVG props', () => {
+    const { getByTestId } = render(
+      <IconLogo data-testid="logo-icon" className="custom-class" aria-label="Logo Icon" />
+    );
+    const icon = getByTestId('logo-icon');
+
+    expect(icon).toHaveClass('custom-class');
+    expect(icon).toHaveAttribute('aria-label', 'Logo Icon');
+  });
+
+  it('has correct number of paths', () => {
+    const { getByTestId } = render(<IconLogo data-testid="logo-icon" />);
+    const icon = getByTestId('logo-icon');
+    const paths = icon.querySelectorAll('path');
+
+    expect(paths.length).toBe(1);
+  });
+
+  it('has correct path attributes', () => {
+    const { getByTestId } = render(<IconLogo data-testid="logo-icon" />);
+    const icon = getByTestId('logo-icon');
+    const path = icon.querySelector('path');
+
+    // Check if the attributes are present in the path's attributes
+    expect(path).toHaveAttribute('fill-rule', 'evenodd');
+    expect(path).toHaveAttribute('clip-rule', 'evenodd');
+  });
+});

--- a/src/ui-kit/icons/IconMenu.test.tsx
+++ b/src/ui-kit/icons/IconMenu.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { IconMenu } from './IconMenu';
+
+describe('IconMenu Component', () => {
+  it('renders with default props', () => {
+    const { getByTestId } = render(<IconMenu data-testid="menu-icon" />);
+    const icon = getByTestId('menu-icon');
+
+    // Check SVG attributes
+    expect(icon).toHaveAttribute('width', '24');
+    expect(icon).toHaveAttribute('height', '24');
+    expect(icon).toHaveAttribute('viewBox', '0 0 24 24');
+
+    // Check fill color is currentColor by default
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill', 'currentColor');
+    });
+  });
+
+  it('renders with custom size and color', () => {
+    const { getByTestId } = render(<IconMenu data-testid="menu-icon" size={32} color="#FF0000" />);
+    const icon = getByTestId('menu-icon');
+
+    // Check custom size
+    expect(icon).toHaveAttribute('width', '32');
+    expect(icon).toHaveAttribute('height', '32');
+
+    // Check custom color
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill', '#FF0000');
+    });
+  });
+
+  it('passes through additional SVG props', () => {
+    const { getByTestId } = render(
+      <IconMenu data-testid="menu-icon" className="custom-class" aria-label="Menu Icon" />
+    );
+    const icon = getByTestId('menu-icon');
+
+    expect(icon).toHaveClass('custom-class');
+    expect(icon).toHaveAttribute('aria-label', 'Menu Icon');
+  });
+
+  it('has correct number of paths', () => {
+    const { getByTestId } = render(<IconMenu data-testid="menu-icon" />);
+    const icon = getByTestId('menu-icon');
+    const paths = icon.querySelectorAll('path');
+
+    expect(paths.length).toBe(3);
+  });
+
+  it('has correct path fill attributes', () => {
+    const { getByTestId } = render(<IconMenu data-testid="menu-icon" />);
+    const icon = getByTestId('menu-icon');
+    const paths = icon.querySelectorAll('path');
+
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill');
+    });
+  });
+});

--- a/src/ui-kit/icons/IconMinus.test.tsx
+++ b/src/ui-kit/icons/IconMinus.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { IconMinus } from './IconMinus';
+
+describe('IconMinus Component', () => {
+  it('renders with default props', () => {
+    const { getByTestId } = render(<IconMinus data-testid="minus-icon" />);
+    const icon = getByTestId('minus-icon');
+
+    // Check SVG attributes
+    expect(icon).toHaveAttribute('width', '24');
+    expect(icon).toHaveAttribute('height', '24');
+    expect(icon).toHaveAttribute('viewBox', '0 0 24 24');
+
+    // Check fill color is currentColor by default
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill', 'currentColor');
+    });
+  });
+
+  it('renders with custom size and color', () => {
+    const { getByTestId } = render(
+      <IconMinus data-testid="minus-icon" size={32} color="#FF0000" />
+    );
+    const icon = getByTestId('minus-icon');
+
+    // Check custom size
+    expect(icon).toHaveAttribute('width', '32');
+    expect(icon).toHaveAttribute('height', '32');
+
+    // Check custom color
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill', '#FF0000');
+    });
+  });
+
+  it('passes through additional SVG props', () => {
+    const { getByTestId } = render(
+      <IconMinus data-testid="minus-icon" className="custom-class" aria-label="Minus Icon" />
+    );
+    const icon = getByTestId('minus-icon');
+
+    expect(icon).toHaveClass('custom-class');
+    expect(icon).toHaveAttribute('aria-label', 'Minus Icon');
+  });
+
+  it('has correct number of paths', () => {
+    const { getByTestId } = render(<IconMinus data-testid="minus-icon" />);
+    const icon = getByTestId('minus-icon');
+    const paths = icon.querySelectorAll('path');
+
+    expect(paths.length).toBe(1);
+  });
+
+  it('has correct path fill attributes', () => {
+    const { getByTestId } = render(<IconMinus data-testid="minus-icon" />);
+    const icon = getByTestId('minus-icon');
+    const paths = icon.querySelectorAll('path');
+
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill');
+    });
+  });
+});

--- a/src/ui-kit/icons/IconPlus.test.tsx
+++ b/src/ui-kit/icons/IconPlus.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { IconPlus } from './IconPlus';
+
+describe('IconPlus Component', () => {
+  it('renders with default props', () => {
+    const { getByTestId } = render(<IconPlus data-testid="plus-icon" />);
+    const icon = getByTestId('plus-icon');
+
+    // Check SVG attributes
+    expect(icon).toHaveAttribute('width', '24');
+    expect(icon).toHaveAttribute('height', '24');
+    expect(icon).toHaveAttribute('viewBox', '0 0 24 24');
+
+    // Check fill color is currentColor by default
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill', 'currentColor');
+    });
+  });
+
+  it('renders with custom size and color', () => {
+    const { getByTestId } = render(<IconPlus data-testid="plus-icon" size={32} color="#FF0000" />);
+    const icon = getByTestId('plus-icon');
+
+    // Check custom size
+    expect(icon).toHaveAttribute('width', '32');
+    expect(icon).toHaveAttribute('height', '32');
+
+    // Check custom color
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('fill', '#FF0000');
+    });
+  });
+
+  it('passes through additional SVG props', () => {
+    const { getByTestId } = render(
+      <IconPlus data-testid="plus-icon" className="custom-class" aria-label="Plus Icon" />
+    );
+    const icon = getByTestId('plus-icon');
+
+    expect(icon).toHaveClass('custom-class');
+    expect(icon).toHaveAttribute('aria-label', 'Plus Icon');
+  });
+
+  it('has correct number of paths', () => {
+    const { getByTestId } = render(<IconPlus data-testid="plus-icon" />);
+    const icon = getByTestId('plus-icon');
+    const paths = icon.querySelectorAll('path');
+
+    expect(paths.length).toBe(1);
+  });
+
+  it('has correct path attributes', () => {
+    const { getByTestId } = render(<IconPlus data-testid="plus-icon" />);
+    const icon = getByTestId('plus-icon');
+    const path = icon.querySelector('path');
+
+    expect(path).toHaveAttribute('fill-rule', 'evenodd');
+    expect(path).toHaveAttribute('clip-rule', 'evenodd');
+  });
+});

--- a/src/ui-kit/icons/IconRedo.test.tsx
+++ b/src/ui-kit/icons/IconRedo.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { IconRedo } from './IconRedo';
+
+describe('IconRedo Component', () => {
+  it('renders with default props', () => {
+    const { getByTestId } = render(<IconRedo data-testid="redo-icon" />);
+    const icon = getByTestId('redo-icon');
+
+    // Check SVG attributes
+    expect(icon).toHaveAttribute('width', '24');
+    expect(icon).toHaveAttribute('height', '24');
+    expect(icon).toHaveAttribute('viewBox', '0 0 16 16');
+
+    // Check default class
+    expect(icon).toHaveClass('stroke-current');
+
+    // Check stroke color is currentColor by default
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('stroke', 'currentColor');
+    });
+  });
+
+  it('renders with custom size and color', () => {
+    const { getByTestId } = render(<IconRedo data-testid="redo-icon" size={32} color="#FF0000" />);
+    const icon = getByTestId('redo-icon');
+
+    // Check custom size
+    expect(icon).toHaveAttribute('width', '32');
+    expect(icon).toHaveAttribute('height', '32');
+
+    // Check custom color
+    const paths = icon.querySelectorAll('path');
+    paths.forEach(path => {
+      expect(path).toHaveAttribute('stroke', '#FF0000');
+    });
+  });
+
+  it('passes through additional SVG props', () => {
+    const { getByTestId } = render(
+      <IconRedo data-testid="redo-icon" className="custom-class" aria-label="Redo Icon" />
+    );
+    const icon = getByTestId('redo-icon');
+
+    expect(icon).toHaveClass('custom-class');
+    expect(icon).toHaveClass('stroke-current');
+    expect(icon).toHaveAttribute('aria-label', 'Redo Icon');
+  });
+
+  it('has correct number of paths', () => {
+    const { getByTestId } = render(<IconRedo data-testid="redo-icon" />);
+    const icon = getByTestId('redo-icon');
+    const paths = icon.querySelectorAll('path');
+
+    expect(paths.length).toBe(1);
+  });
+
+  it('has correct path attributes', () => {
+    const { getByTestId } = render(<IconRedo data-testid="redo-icon" />);
+    const icon = getByTestId('redo-icon');
+    const path = icon.querySelector('path');
+
+    expect(path).toHaveAttribute('stroke-width', '2');
+    expect(path).toHaveAttribute('stroke-linecap', 'round');
+    expect(path).toHaveAttribute('stroke-linejoin', 'round');
+  });
+
+  it('combines className with default stroke class', () => {
+    const { getByTestId } = render(<IconRedo data-testid="redo-icon" className="test-class" />);
+    const icon = getByTestId('redo-icon');
+
+    expect(icon).toHaveClass('stroke-current');
+    expect(icon).toHaveClass('test-class');
+  });
+});

--- a/src/ui-kit/icons/IconReload.test.tsx
+++ b/src/ui-kit/icons/IconReload.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconReload } from './IconReload';
+
+describe('IconReload Component', () => {
+  it('renders with default props', () => {
+    render(<IconReload data-testid="reload-icon" />);
+    const svg = screen.getByTestId('reload-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 16 16');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconReload size={32} data-testid="reload-icon" />);
+    const svg = screen.getByTestId('reload-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color', () => {
+    render(<IconReload color="red" data-testid="reload-icon" />);
+    const paths = screen.getByTestId('reload-icon').querySelectorAll('path');
+
+    paths.forEach(path => {
+      const fillOrStroke = path.hasAttribute('stroke') ? 'stroke' : 'fill';
+      expect(path).toHaveAttribute(fillOrStroke, 'red');
+    });
+  });
+
+  it('passes through additional native props', () => {
+    render(<IconReload data-testid="reload-icon" className="custom-class" aria-label="Reload" />);
+    const svg = screen.getByTestId('reload-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Reload');
+  });
+});

--- a/src/ui-kit/icons/IconSave.test.tsx
+++ b/src/ui-kit/icons/IconSave.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconSave } from './IconSave';
+
+describe('IconSave Component', () => {
+  it('renders with default props', () => {
+    render(<IconSave data-testid="save-icon" />);
+    const svg = screen.getByTestId('save-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconSave size={32} data-testid="save-icon" />);
+    const svg = screen.getByTestId('save-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color', () => {
+    render(<IconSave color="red" data-testid="save-icon" />);
+    const path = screen.getByTestId('save-icon').querySelector('path');
+
+    expect(path).toHaveAttribute('stroke', 'red');
+  });
+
+  it('passes through additional native props', () => {
+    render(<IconSave data-testid="save-icon" className="custom-class" aria-label="Save" />);
+    const svg = screen.getByTestId('save-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Save');
+  });
+});

--- a/src/ui-kit/icons/IconSearch.test.tsx
+++ b/src/ui-kit/icons/IconSearch.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconSearch } from './IconSearch';
+
+describe('IconSearch Component', () => {
+  it('renders with default props', () => {
+    render(<IconSearch data-testid="search-icon" />);
+    const svg = screen.getByTestId('search-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 20 18');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconSearch size={32} data-testid="search-icon" />);
+    const svg = screen.getByTestId('search-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color', () => {
+    render(<IconSearch color="red" data-testid="search-icon" />);
+    const path = screen.getByTestId('search-icon').querySelector('path');
+
+    expect(path).toHaveAttribute('fill', 'red');
+  });
+
+  it('passes through additional native props', () => {
+    render(<IconSearch data-testid="search-icon" className="custom-class" aria-label="Search" />);
+    const svg = screen.getByTestId('search-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Search');
+  });
+});

--- a/src/ui-kit/icons/IconSend.test.tsx
+++ b/src/ui-kit/icons/IconSend.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconSend } from './IconSend';
+
+describe('IconSend Component', () => {
+  it('renders with default props', () => {
+    render(<IconSend data-testid="send-icon" />);
+    const svg = screen.getByTestId('send-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconSend size={32} data-testid="send-icon" />);
+    const svg = screen.getByTestId('send-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color', () => {
+    render(<IconSend color="red" data-testid="send-icon" />);
+    const path = screen.getByTestId('send-icon').querySelector('path');
+
+    expect(path).toHaveAttribute('stroke', 'red');
+  });
+
+  it('passes through additional native props', () => {
+    render(<IconSend data-testid="send-icon" className="custom-class" aria-label="Send" />);
+    const svg = screen.getByTestId('send-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Send');
+  });
+});

--- a/src/ui-kit/icons/IconSettings.test.tsx
+++ b/src/ui-kit/icons/IconSettings.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconSettings } from './IconSettings';
+
+describe('IconSettings Component', () => {
+  it('renders with default props', () => {
+    render(<IconSettings data-testid="settings-icon" />);
+    const svg = screen.getByTestId('settings-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconSettings size={32} data-testid="settings-icon" />);
+    const svg = screen.getByTestId('settings-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color for both fill and stroke paths', () => {
+    render(<IconSettings color="red" data-testid="settings-icon" />);
+    const paths = screen.getByTestId('settings-icon').querySelectorAll('path');
+    // First path uses fill
+    expect(paths[0]).toHaveAttribute('fill', 'red');
+    // Second path uses stroke
+    expect(paths[1]).toHaveAttribute('stroke', 'red');
+  });
+
+  it('passes through additional native props', () => {
+    render(
+      <IconSettings data-testid="settings-icon" className="custom-class" aria-label="Settings" />
+    );
+    const svg = screen.getByTestId('settings-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'Settings');
+  });
+});

--- a/src/ui-kit/icons/IconUser.test.tsx
+++ b/src/ui-kit/icons/IconUser.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IconUser } from './IconUser';
+
+describe('IconUser Component', () => {
+  it('renders with default props', () => {
+    render(<IconUser data-testid="user-icon" />);
+    const svg = screen.getByTestId('user-icon');
+
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('viewBox', '0 0 20 20');
+  });
+
+  it('renders with custom size', () => {
+    render(<IconUser size={32} data-testid="user-icon" />);
+    const svg = screen.getByTestId('user-icon');
+
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('renders with custom color and correct stroke attributes', () => {
+    render(<IconUser color="red" data-testid="user-icon" />);
+    const path = screen.getByTestId('user-icon').querySelector('path');
+
+    expect(path).toHaveAttribute('stroke', 'red');
+    expect(path).toHaveAttribute('stroke-width', '1.66667');
+    expect(path).toHaveAttribute('stroke-linecap', 'round');
+    expect(path).toHaveAttribute('stroke-linejoin', 'round');
+  });
+
+  it('passes through additional native props', () => {
+    render(<IconUser data-testid="user-icon" className="custom-class" aria-label="User" />);
+    const svg = screen.getByTestId('user-icon');
+
+    expect(svg).toHaveClass('custom-class');
+    expect(svg).toHaveAttribute('aria-label', 'User');
+  });
+});


### PR DESCRIPTION
## Description

Added unit tests for IconSend, IconSettings, and IconUser components to improve test coverage of the UI kit icons.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] I have tested these changes locally

## Additional Notes

Added comprehensive tests that verify:
- Default rendering with correct size and viewBox
- Custom size rendering
- Custom color application (fill/stroke attributes)
- Proper handling of additional native props

All tests have been run locally and pass successfully.